### PR TITLE
NIRSpec DR4 catalogue update

### DIFF
--- a/_posts/2025-10-01-jades-dr4.markdown
+++ b/_posts/2025-10-01-jades-dr4.markdown
@@ -1,7 +1,7 @@
 ---
 layout: single
 title:  "JADES Fourth Data Release"
-date:   2025-10-01 20:00:00 -0700
+date:   2025-10-01 09:00:00 -0700
 author: JADES Collaboration
 categories: high-redshift
 ---
@@ -10,26 +10,20 @@ JADES has issued its fourth public release!  This release
 features all of the JADES spectroscopy of the entire survey,
 a total of 5190 targets observed with the NIRSpec prism and all
 of the medium-resolution gratings.  A total of 3787 spectroscopic
-redshifts are reported, including XYZ at z>5.  The data release 
+redshifts are reported, including 974 at z>4.  The data release 
 paper describes the sample in detail, including many aspects of the 
 very detailed data reduction and vetting of these beautiful spectra.
 
-The release also includes our first release of imaging and photometric
-catalogs in the GOODS-N region, containing 85,000 objects over 56 square arcminutes, most measured in 9 filters.  
 
-The images and catalogs are visualized through the JADES FITSmap viewer,
+The images and catalogues are visualized through the JADES FITSmap viewer,
 linked in this website.  Be sure to use the "NIRSpec Spectra" overlay to
 see the spectroscopy!
 
 Here is a visualization of the spectroscopy, showing the sweep of emission lines through a progression of redshift.
 
-![JADES Third Data Release in GOODS-N](/assets/images/dr3_spectral_stack.png)
+![JADES Fourth Data Release in GOODS-N](/assets/images/dr3_spectral_stack.png)
 
-Below are an image of the full GOODS-N data release and a cutout of the 
-famous Hubble Deep Field region, now shown here with exquisitely deep infrared
-imaging..
+You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius.
 
-![JADES Third Data Release in GOODS-N](/assets/images/goods-n-rgb.png)
-
-![JADES view of the Hubble Deep Field](/assets/images/jwst_hdf_annotated_lr.png)
+The final data release of the NIRCam imaging from our survey will be in the upcoming Datar Release 5 - stay tuned for more information. 
 

--- a/_posts/2025-10-01-jades-dr4.markdown
+++ b/_posts/2025-10-01-jades-dr4.markdown
@@ -1,0 +1,35 @@
+---
+layout: single
+title:  "JADES Fourth Data Release"
+date:   2025-10-01 20:00:00 -0700
+author: JADES Collaboration
+categories: high-redshift
+---
+
+JADES has issued its fourth public release!  This release
+features all of the JADES spectroscopy of the entire survey,
+a total of 5190 targets observed with the NIRSpec prism and all
+of the medium-resolution gratings.  A total of 3787 spectroscopic
+redshifts are reported, including XYZ at z>5.  The data release 
+paper describes the sample in detail, including many aspects of the 
+very detailed data reduction and vetting of these beautiful spectra.
+
+The release also includes our first release of imaging and photometric
+catalogs in the GOODS-N region, containing 85,000 objects over 56 square arcminutes, most measured in 9 filters.  
+
+The images and catalogs are visualized through the JADES FITSmap viewer,
+linked in this website.  Be sure to use the "NIRSpec Spectra" overlay to
+see the spectroscopy!
+
+Here is a visualization of the spectroscopy, showing the sweep of emission lines through a progression of redshift.
+
+![JADES Third Data Release in GOODS-N](/assets/images/dr3_spectral_stack.png)
+
+Below are an image of the full GOODS-N data release and a cutout of the 
+famous Hubble Deep Field region, now shown here with exquisitely deep infrared
+imaging..
+
+![JADES Third Data Release in GOODS-N](/assets/images/goods-n-rgb.png)
+
+![JADES view of the Hubble Deep Field](/assets/images/jwst_hdf_annotated_lr.png)
+

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -8,7 +8,7 @@ permalink: /scientists/data.html
 
 ### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey - Data release 4 
 
-For any information about the DR4 and JADES spectroscopic survey, please refer to the <a href="https://arxiv.org/abs/2404.06531" target="_blank"> and <a href="https://arxiv.org/abs/2404.06531" target="_blank"> articles by the JADES team</a>.
+For any information about the DR4 and JADES spectroscopic survey, please refer to the articles by the JADES team:  <a href="https://arxiv.org/abs/2404.06531" target="_blank">Paper I</a> and <a href="https://arxiv.org/abs/2404.06531" target="_blank"> Paper II</a>.
 If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker et al. 2023b), D'Eugenio et al. (2025), Curtis-Lake et al. (2025) and Scholtz et al. (2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
 
 ### Reduced and calibrated data included in this release

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -19,7 +19,7 @@ You can access the spectroscopic data in the Data Release 4 - <a href="https://j
 We present full spectroscopic measurements of the JADES spectroscopic sample across different extrations. The full catalogue can be accessed below: 
 
 0. <a href="https://jades.herts.ac.uk/DR4/Readme_DR4_catalogues.md" target="_blank">README</a>
-1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_internal_beta_v0.5.1.2b.fits" target="_blank"> Full DR spectroscopic catalogue</a>
+1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_external.fits" target="_blank"> Full DR spectroscopic catalogue</a>
 
 You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius. The Online database then allows you to display the NIRCam stamps, best fits for the R100 and R1000 data as well as download the full flux catalogue based on your search. 
 

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -4,6 +4,25 @@ title: Data Access
 permalink: /scientists/data.html
 ---
 
+# JADES Data Release 4
+
+### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey - Data release 4 
+
+For any information about the DR4 and JADES spectroscopic survey, please refer to the <a href="https://arxiv.org/abs/2404.06531" target="_blank"> and <a href="https://arxiv.org/abs/2404.06531" target="_blank"> articles by the JADES team</a>.
+If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker et al. 2023b), D'Eugenio et al. (2025), Curtis-Lake et al. (2025) and Scholtz et al. (2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
+
+### Reduced and calibrated data included in this release
+You can access the spectroscopic data in the Data Release 4 - <a href="https://jades.herts.ac.uk/DR4/" target="_blank"> using the wget commands.
+
+### Catalogues included in this release
+
+0. <a href="https://jades.herts.ac.uk/DR4/Readme_DR4_catalogues.md" target="_blank">README</a>
+1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_internal_beta_v0.5.1.2b.fits" target="_blank"> Full DR spectroscopic catalogue</a>
+
+You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius. The Online database then allows you to display the NIRCam stamps, best fits for the R100 and R1000 data as well as download the full flux catalogue based on your search. 
+
+
+
 # JADES Data Release 3
 
 ### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -8,7 +8,7 @@ permalink: /scientists/data.html
 
 ### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey - Data release 4 
 
-For any information about the DR4 and JADES spectroscopic survey, please refer to the articles by the JADES team:  <a href="https://arxiv.org/abs/2404.06531" target="_blank">Paper I</a> and <a href="https://arxiv.org/abs/2404.06531" target="_blank"> Paper II</a>.
+For any information about the DR4 and JADES spectroscopic survey, please refer to the articles by the JADES team:  <a href="https://arxiv.org/" target="_blank">Paper I</a> and <a href="https://arxiv.org/" target="_blank"> Paper II</a>.
 If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker et al. 2023b), D'Eugenio et al. (2025), Curtis-Lake et al. (2025) and Scholtz et al. (2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
 
 ### Reduced and calibrated data included in this release

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -19,7 +19,7 @@ You can access the spectroscopic data in the Data Release 4 - <a href="https://j
 We present full spectroscopic measurements of the JADES spectroscopic sample across different extrations. The full catalogue can be accessed below: 
 
 0. <a href="https://jades.herts.ac.uk/DR4/Readme_DR4_catalogues.md" target="_blank">README</a>
-1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_external.fits" target="_blank"> Full DR spectroscopic catalogue</a>
+1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_external_v1.2.1.fits" target="_blank"> Full DR spectroscopic catalogue</a>
 
 You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius. The Online database then allows you to display the NIRCam stamps, best fits for the R100 and R1000 data as well as download the full flux catalogue based on your search. 
 

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -6,10 +6,9 @@ permalink: /scientists/data.html
 
 
 
-# JADES Data Release 4
+# JADES Data Release 4: The full spectroscopic sample
 
-### Data release 4: The full spectroscopic sample
-#### Temporary access to the public data products
+### Temporary access to the public data products
 
 For any information about the DR4 and JADES spectroscopic survey, please refer to the articles by the JADES team:  <a href="https://arxiv.org/" target="_blank">Paper I</a> and <a href="https://arxiv.org/" target="_blank"> Paper II</a>.
 If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES NIRSpec DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker, Cameron, Curtis-Lake et al. 2023b), DR3 - (D'Eugenio et al., 2025), DR4 Paper I (Curtis-Lake, Cameron, Bunker et al., 2025) and DR4 Paper II (Scholtz, Carniani et al. 2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -8,7 +8,8 @@ permalink: /scientists/data.html
 
 # JADES Data Release 4
 
-### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey - Data release 4: The full spectroscopic sample
+### Data release 4: The full spectroscopic sample
+#### Temporary access to the public data products
 
 For any information about the DR4 and JADES spectroscopic survey, please refer to the articles by the JADES team:  <a href="https://arxiv.org/" target="_blank">Paper I</a> and <a href="https://arxiv.org/" target="_blank"> Paper II</a>.
 If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES NIRSpec DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker, Cameron, Curtis-Lake et al. 2023b), DR3 - (D'Eugenio et al., 2025), DR4 Paper I (Curtis-Lake, Cameron, Bunker et al., 2025) and DR4 Paper II (Scholtz, Carniani et al. 2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -11,7 +11,7 @@ permalink: /scientists/data.html
 ### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey - Data release 4: The full spectroscopic sample
 
 For any information about the DR4 and JADES spectroscopic survey, please refer to the articles by the JADES team:  <a href="https://arxiv.org/" target="_blank">Paper I</a> and <a href="https://arxiv.org/" target="_blank"> Paper II</a>.
-If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker, Cameron, Curtis-Lake et al. 2023b), DR3 - (D'Eugenio et al., 2025), DR4 Paper I (Curtis-Lake, Cameron, Bunker et al., 2025) and DR4 Paper II (Scholtz, Carniani et al. 2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
+If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES NIRSpec DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker, Cameron, Curtis-Lake et al. 2023b), DR3 - (D'Eugenio et al., 2025), DR4 Paper I (Curtis-Lake, Cameron, Bunker et al., 2025) and DR4 Paper II (Scholtz, Carniani et al. 2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
 
 ### Reduced and calibrated data included in this release
 You can access the spectroscopic data in the Data Release 4 - <a href="https://jades.herts.ac.uk/DR4/" target="_blank">at this website</a> directly or using the wget commands.
@@ -25,11 +25,11 @@ We present full spectroscopic measurements of the JADES spectroscopic sample acr
 
 You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius. The Online database then allows you to display the NIRCam stamps, best fits for the R100 and R1000 data as well as download the full flux catalogue based on your search and filters. 
 
-The team anticipates the full JADES imaging products to feature in a future data release, Data Release 5.  At this point <a href="https://jades-survey.github.io/viewer/" target="_blank">the fitsmap interactive viewer</a> will be updated.
+The team anticipates the full JADES imaging products to feature in a future data release, Data Release 5.  At that point the <a href="https://jades-survey.github.io/viewer/" target="_blank">fitsmap interactive viewer</a> will be updated.
 
 # JADES HLSP page
 
-### All previus JADES data releases, including documentation are maintained at the  <a href="https://archive.stsci.edu/hlsp/jades" target="_blank">JADES HLSP page</a>.  We are working to ensure JADES Data Release 4 will also be available there in the near future.
+All previous JADES data releases, including documentation are maintained at the  <a href="https://archive.stsci.edu/hlsp/jades" target="_blank">JADES HLSP page</a>.  We are working to ensure JADES Data Release 4 will also be available there in the near future.
 
 
 # Previous Data Release Information

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -12,9 +12,11 @@ For any information about the DR4 and JADES spectroscopic survey, please refer t
 If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker et al. 2023b), D'Eugenio et al. (2025), Curtis-Lake et al. (2025) and Scholtz et al. (2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
 
 ### Reduced and calibrated data included in this release
-You can access the spectroscopic data in the Data Release 4 - <a href="https://jades.herts.ac.uk/DR4/" target="_blank"> using the wget commands.
+You can access the spectroscopic data in the Data Release 4 - <a href="https://jades.herts.ac.uk/DR4/" target="_blank"></a> directly or using the wget commands.
 
 ### Catalogues included in this release
+
+We present full spectroscopic measurements of the JADES spectroscopic sample across different extrations. The full catalogue can be accessed below: 
 
 0. <a href="https://jades.herts.ac.uk/DR4/Readme_DR4_catalogues.md" target="_blank">README</a>
 1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_internal_beta_v0.5.1.2b.fits" target="_blank"> Full DR spectroscopic catalogue</a>

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -19,7 +19,7 @@ You can access the spectroscopic data in the Data Release 4 - <a href="https://j
 We present full spectroscopic measurements of the JADES spectroscopic sample across different extrations. The full catalogue can be accessed below: 
 
 0. <a href="https://jades.herts.ac.uk/DR4/Readme_DR4_catalogues.md" target="_blank">README</a>
-1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_external_v1.2.1.fits" target="_blank"> Full DR spectroscopic catalogue</a>
+1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_external_v1.2.1.fits" target="_blank"> Full NIRSpec spectroscopic flux catalogue</a>
 
 You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius. The Online database then allows you to display the NIRCam stamps, best fits for the R100 and R1000 data as well as download the full flux catalogue based on your search. 
 

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -12,7 +12,7 @@ For any information about the DR4 and JADES spectroscopic survey, please refer t
 If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker et al. 2023b), D'Eugenio et al. (2025), Curtis-Lake et al. (2025) and Scholtz et al. (2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
 
 ### Reduced and calibrated data included in this release
-You can access the spectroscopic data in the Data Release 4 - <a href="https://jades.herts.ac.uk/DR4/" target="_blank"></a> directly or using the wget commands.
+You can access the spectroscopic data in the Data Release 4 - <a href="https://jades.herts.ac.uk/DR4/" target="_blank">at this website</a> directly or using the wget commands.
 
 ### Catalogues included in this release
 

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -21,7 +21,7 @@ We present full spectroscopic measurements of the JADES spectroscopic sample acr
 0. <a href="https://jades.herts.ac.uk/DR4/Readme_DR4_catalogues.md" target="_blank">README</a>
 1. <a href="https://jades.herts.ac.uk/DR4/Combined_DR4_external_v1.2.1.fits" target="_blank"> Full NIRSpec spectroscopic flux catalogue</a>
 
-You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius. The Online database then allows you to display the NIRCam stamps, best fits for the R100 and R1000 data as well as download the full flux catalogue based on your search. 
+You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius. The Online database then allows you to display the NIRCam stamps, best fits for the R100 and R1000 data as well as download the full flux catalogue based on your search and filters. 
 
 
 

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -13,7 +13,7 @@ permalink: /scientists/data.html
 For any information about the DR4 and JADES spectroscopic survey, please refer to the articles by the JADES team:  <a href="https://arxiv.org/" target="_blank">Paper I</a> and <a href="https://arxiv.org/" target="_blank"> Paper II</a>.
 If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES NIRSpec DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker, Cameron, Curtis-Lake et al. 2023b), DR3 - (D'Eugenio et al., 2025), DR4 Paper I (Curtis-Lake, Cameron, Bunker et al., 2025) and DR4 Paper II (Scholtz, Carniani et al. 2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
 
-### Reduced and calibrated data included in this release
+### Reduced and calibrated 1D and 2D spectra included in this release
 You can access the spectroscopic data in the Data Release 4 - <a href="https://jades.herts.ac.uk/DR4/" target="_blank">at this website</a> directly or using the wget commands.
 
 ### Catalogues included in this release
@@ -35,7 +35,7 @@ All previous JADES data releases, including documentation are maintained at the 
 # Previous Data Release Information
 
 
-# JADES Data Release 3
+## JADES Data Release 3
 
 ### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey
 

--- a/scientists/data.markdown
+++ b/scientists/data.markdown
@@ -4,12 +4,14 @@ title: Data Access
 permalink: /scientists/data.html
 ---
 
+
+
 # JADES Data Release 4
 
-### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey - Data release 4 
+### Temporary access to the public data products from the JWST Advanced Deep Extragalactic Survey - Data release 4: The full spectroscopic sample
 
 For any information about the DR4 and JADES spectroscopic survey, please refer to the articles by the JADES team:  <a href="https://arxiv.org/" target="_blank">Paper I</a> and <a href="https://arxiv.org/" target="_blank"> Paper II</a>.
-If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker et al. 2023b), D'Eugenio et al. (2025), Curtis-Lake et al. (2025) and Scholtz et al. (2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
+If you use these data products in your research, we would appreciate a citation to the JADES overview article (Eisenstein et al. 2023a), the JADES DR1 article (detailing the data reduction and spectroscopic data from PID 1210; Bunker, Cameron, Curtis-Lake et al. 2023b), DR3 - (D'Eugenio et al., 2025), DR4 Paper I (Curtis-Lake, Cameron, Bunker et al., 2025) and DR4 Paper II (Scholtz, Carniani et al. 2025).  Depending on the data products used, further citations may be appropriate; Eisenstein et al. (2023b; PID 3215), Rieke et al. (2023; GOODS-S imaging) and Hainline et al. (2023; photometric redshifts).
 
 ### Reduced and calibrated data included in this release
 You can access the spectroscopic data in the Data Release 4 - <a href="https://jades.herts.ac.uk/DR4/" target="_blank">at this website</a> directly or using the wget commands.
@@ -23,6 +25,14 @@ We present full spectroscopic measurements of the JADES spectroscopic sample acr
 
 You can also search the <a href="https://jades.herts.ac.uk/search/" target="_blank">JADES Online Database</a> which enables you to filter the JADES spectroscopic catalogue by redshift, redshift quality flag, emission line fluxes or search by coordinates and search radius. The Online database then allows you to display the NIRCam stamps, best fits for the R100 and R1000 data as well as download the full flux catalogue based on your search and filters. 
 
+The team anticipates the full JADES imaging products to feature in a future data release, Data Release 5.  At this point <a href="https://jades-survey.github.io/viewer/" target="_blank">the fitsmap interactive viewer</a> will be updated.
+
+# JADES HLSP page
+
+### All previus JADES data releases, including documentation are maintained at the  <a href="https://archive.stsci.edu/hlsp/jades" target="_blank">JADES HLSP page</a>.  We are working to ensure JADES Data Release 4 will also be available there in the near future.
+
+
+# Previous Data Release Information
 
 
 # JADES Data Release 3


### PR DESCRIPTION
This is an update for the NIRSpec DR4 release for the morning of 1/10/2025 Europe time. I have added links and more info to the data.markdown with full info about DR4, while also adding a news item to the News section of the website. 